### PR TITLE
changing the version of github actions cache to be v4

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -57,7 +57,7 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         env:
           cache-name: cache-artifacts
         with:


### PR DESCRIPTION
Hey just correcting for this deprecation that occurred in the CI.yml file for github actions cache. We're pushing the version to 4.0 as they are deprecating all versions before 4.0. Here's more info on the deprecation https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down . 